### PR TITLE
Fix type definitions

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -20,5 +20,5 @@ declare module 'redux-localstorage-simple' {
   export function save(options?:RLSOptions):Middleware
   export function load(options?:LoadOptions):object
   export function clear(options?:ClearOptions):void
-  export function combineLoads(...loads?:object[]):object
+  export function combineLoads(...loads:object[]):object
 }


### PR DESCRIPTION
rest parameters are always optional so the `?` creates a compile error as it is not a array type