### PR TITLE
Feature/namespace separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ The `save` method takes a optional configuration object as an argument. It has t
 {
     [Array states],
     [String namespace],
+    [String namespaceSeparator],
     [Number debounce]
 }
 ```
 
 - states (Array, optional) - This is an optional array of strings specifying which parts of the Redux state tree you would like to save to LocalStorage. e.g. ["user", "products"]. Typically states have identical names to your Redux reducers. If you do not specify any states then your entire Redux state tree will be saved to LocalStorage.
 - namespace (String, optional) - This is an optional string specifying the namespace to add to your LocalStorage items. For example if you have a part of your Redux state tree called "user" and you specify the namespace "my_cool_app", it will be saved to LocalStorage as "my_cool_app_user"
+- namespaceSeparator (String, optional) - This is an optional string specifying the separator used between the namespace and the state keys. Using previous example with the namespaceSeparator set top "::", the key saved to the LocalStorage would be "my_cool_app::user"
 - debounce (Number, optional) - Debouncing period (in milliseconds) to wait before saving to LocalStorage. Use this as a performance optimization if you feel you are saving to LocalStorage too often. Recommended value: 500 - 1000 milliseconds
 
 #### Examples
@@ -81,6 +83,12 @@ Save the entire state tree under the namespace "my_cool_app". The key "my_cool_a
 
 ```js
 save({ namespace: "my_cool_app" })
+```
+
+Save the entire state tree under the namespace "my_cool_app" with the separator "::".
+
+```js
+save({ namespace: "my_cool_app", namespaceSeparator: "::" })
 ```
 
 Save the entire state tree only after a debouncing period of 500 milliseconds has elapsed
@@ -114,6 +122,7 @@ The `load` method takes a optional configuration object as an argument. It has t
 {
     [Array states],    
     [String namespace],
+    [String namespaceSeparator],
     [Object preloadedState],
     [Boolean disableWarnings]
 }
@@ -121,6 +130,7 @@ The `load` method takes a optional configuration object as an argument. It has t
 
 - states (Array, optional) - This is an optional array of strings specifying which parts of the Redux state tree you would like to load from LocalStorage. e.g. ["user", "products"]. These parts of the state tree must have been previously saved using the `save` method. Typically states have identical names to your Redux reducers. If you do not specify any states then your entire Redux state tree will be loaded from LocalStorage.
 - namespace (String, optional) - If you have saved your entire state tree or parts of your state tree with a namespace you will need to specify it in order to load it from LocalStorage.
+- namespaceSeparator (String, optional) - If you have saved entire state tree or parts of your state tree with a namespaceSeparator, you will need to specify it in order to load it from LocalStorage.
 - preloadedState (Object, optional) - Passthrough for the `preloadedState` argument in Redux's `createStore` method. See section **Advanced Usage** below.
 - disableWarnings (Boolean, optional) - When you first try to a load a state from LocalStorage you will see a warning in the JavaScript console informing you that this state load is invalid. This is because the `save` method hasn't been called yet and this state has yet to been written to LocalStorage. You may not care to see this warning so to disable it set `disableWarnings` to true.
 
@@ -142,6 +152,12 @@ Load the entire state tree which was previously saved with the namespace "my_coo
 
 ```js
 load({ namespace: "my_cool_app" })
+```
+
+Load the entire state tree which was previously saved with the namespace "my_cool_app" and a namespaceSeparator "::".
+
+```js
+load({ namespace: "my_cool_app", namespaceSeparator: "::" })
 ```
 
 Load specific parts of the state tree which was previously saved with the namespace "my_cool_app".

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install --save redux-localstorage-simple
 
 ## Usage Example (ES6 code)
 
-```sh
+```js
 import { applyMiddleware, createStore } from "redux"
 import reducer from "./reducer"
 
@@ -42,7 +42,7 @@ const store = createStoreWithMiddleware(
 
 Saving to LocalStorage is achieved using [Redux middleware](http://redux.js.org/docs/advanced/Middleware.html) and saves each time an action is handled by your reducer. You will need to pass the `save` method into Redux's `applyMiddleware` method, like so...
 
-```sh
+```js
 applyMiddleware(save())
 ```
 
@@ -51,7 +51,7 @@ See the Usage Example above to get a better idea of how this works.
 #### Arguments
 The `save` method takes a optional configuration object as an argument. It has the following properties:
 
-```sh
+```
 {
     [Array states],
     [String namespace],
@@ -67,31 +67,31 @@ The `save` method takes a optional configuration object as an argument. It has t
 
 Save entire state tree - EASIEST OPTION.
 
-```sh
+```js
 save()
 ```
 
 Save specific parts of the state tree.
 
-```sh
+```js
 save({ states: ["user", "products"] })
 ```
 
 Save the entire state tree under the namespace "my_cool_app". The key "my_cool_app" will appear in LocalStorage.
 
-```sh
+```js
 save({ namespace: "my_cool_app" })
 ```
 
 Save the entire state tree only after a debouncing period of 500 milliseconds has elapsed
 
-```sh
+```js
 save({ debounce: 500 })
 ```
 
 Save specific parts of the state tree with the namespace "my_cool_app". The keys "my_cool_app_user" and "my_cool_app_products" will appear in LocalStorage.
 
-```sh
+```js
 save({
     states: ["user", "products"],
     namespace: "my_cool_app"
@@ -101,7 +101,7 @@ save({
 ### load([Object config])
 Loading Redux state from LocalStorage happens during creation of the Redux store.
 
-```sh
+```js
 createStore(reducer, load())    
 ```
 
@@ -110,7 +110,7 @@ See the Usage Example above to get a better idea of how this works.
 #### Arguments
 The `load` method takes a optional configuration object as an argument. It has the following properties:
 
-```sh
+```
 {
     [Array states],    
     [String namespace],
@@ -128,25 +128,25 @@ The `load` method takes a optional configuration object as an argument. It has t
 
 Load entire state tree - EASIEST OPTION.
 
-```sh
+```js
 load()
 ```
 
 Load specific parts of the state tree.
 
-```sh
+```js
 load({ states: ["user", "products"] })
 ```
 
 Load the entire state tree which was previously saved with the namespace "my_cool_app".
 
-```sh
+```js
 load({ namespace: "my_cool_app" })
 ```
 
 Load specific parts of the state tree which was previously saved with the namespace "my_cool_app".
 
-```sh
+```js
 load({ 
     states: ["user", "products"],
     namespace: "my_cool_app"
@@ -163,20 +163,20 @@ If you provided more than one call to `save` in your Redux middleware you will n
 
 Load parts of the state tree saved with different namespaces. Here are the `save` methods in your Redux middleware:
 
-```sh
+```js
 applyMiddleware(
     save({ states: ["user"], namespace: "account_stuff" }),
-    save({ states: ["products", "categories"], namespace: "site_stuff" )
+    save({ states: ["products", "categories"], namespace: "site_stuff" })
 )
 ```
 
 The corresponding use of `combineLoads` looks like this:
 
-```sh
+```js
 combineLoads( 
     load({ states: ["user"], namespace: "account_stuff" }),
-    load({ states: ["products", "categories"], namespace: "site_stuff" )
-)   
+    load({ states: ["products", "categories"], namespace: "site_stuff" })
+)
 ```
 
 ### clear([Object config])
@@ -187,7 +187,7 @@ Clears all Redux state tree data from LocalStorage. Note: only clears data which
 
 The `clear` method takes a optional configuration object as an argument. It has the following properties:
 
-```sh
+```
 {
     [String namespace]
 }
@@ -199,13 +199,13 @@ The `clear` method takes a optional configuration object as an argument. It has 
 
 Clear all Redux state tree data saved without a namespace.
 
-```sh
+```js
 clear()
 ```
 
 Clear Redux state tree data saved with a namespace.
 
-```sh
+```js
 clear({
     namespace: "my_cool_app"
 })  
@@ -217,22 +217,22 @@ In a more complex project you may find that you are saving unnecessary reducer d
 
 First let's look at a normal example. Let's say you have a reducer called `settings` and its state tree looks like this:
 
-```sh
+```js
 const settingsReducerInitialState = {
-    theme: 'light'
+    theme: 'light',
     itemsPerPage: 10
 }
 ```
 
 Using `redux-localstorage-simple`'s `save()` method for the `settings` reducer would look like this:
 
-```sh
+```js
 save({ states: ["settings"] })
 ```
 
 This saves all of the `settings` reducer's properties to LocalStorage. But wait, what if we really only care about saving the user's choice of `theme` and not `itemsPerPage`. Here's how to fix this:
 
-```sh
+```js
 save({ states: ["settings.theme"] })
 ```
 
@@ -240,7 +240,7 @@ This saves only the `theme` setting to LocalStorage. However this presents an ad
 
 Yes in most cases it would. So to prevent this you can use the `preloadedState` argument in the `load()` method to provide some initial data.
 
-```sh
+```js
 load({
     states: ["settings.theme"],
     preloadedState: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -21,6 +21,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 var MODULE_NAME = '[Redux-LocalStorage-Simple]';
 var NAMESPACE_DEFAULT = 'redux_localstorage_simple';
+var NAMESPACE_SEPARATOR_DEFAULT = '_';
 var STATES_DEFAULT = [];
 var DEBOUNCE_DEFAULT = 0;
 var IMMUTABLEJS_DEFAULT = false;
@@ -179,6 +180,8 @@ function save() {
       states = _ref$states === undefined ? STATES_DEFAULT : _ref$states,
       _ref$namespace = _ref.namespace,
       namespace = _ref$namespace === undefined ? NAMESPACE_DEFAULT : _ref$namespace,
+      _ref$namespaceSeparat = _ref.namespaceSeparator,
+      namespaceSeparator = _ref$namespaceSeparat === undefined ? NAMESPACE_SEPARATOR_DEFAULT : _ref$namespaceSeparat,
       _ref$debounce = _ref.debounce,
       debounce = _ref$debounce === undefined ? DEBOUNCE_DEFAULT : _ref$debounce;
 
@@ -197,6 +200,12 @@ function save() {
         if (!isString(namespace)) {
           console.error(MODULE_NAME, "'namespace' parameter in 'save()' method was passed a non-string value. Setting default value instead. Check your 'save()' method.");
           namespace = NAMESPACE_DEFAULT;
+        }
+
+        // Validate 'namespaceSeparator' parameter
+        if (!isString(namespaceSeparator)) {
+          console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'load()' method was passed a non-string value. Setting default value instead. Check your 'load()' method.");
+          namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT;
         }
 
         // Validate 'debounce' parameter
@@ -240,10 +249,10 @@ function save() {
             states.forEach(function (state) {
               var stateForLocalStorage = getStateForLocalStorage(state, store.getState());
               if (stateForLocalStorage) {
-                localStorage[namespace + '_' + state] = JSON.stringify(stateForLocalStorage);
+                localStorage[namespace + namespaceSeparator + state] = JSON.stringify(stateForLocalStorage);
               } else {
                 // Make sure nothing is ever saved for this incorrect state
-                localStorage.removeItem(namespace + '_' + state);
+                localStorage.removeItem(namespace + namespaceSeparator + state);
               }
             });
           }
@@ -296,6 +305,8 @@ function load() {
       immutablejs = _ref2$immutablejs === undefined ? IMMUTABLEJS_DEFAULT : _ref2$immutablejs,
       _ref2$namespace = _ref2.namespace,
       namespace = _ref2$namespace === undefined ? NAMESPACE_DEFAULT : _ref2$namespace,
+      _ref2$namespaceSepara = _ref2.namespaceSeparator,
+      namespaceSeparator = _ref2$namespaceSepara === undefined ? NAMESPACE_SEPARATOR_DEFAULT : _ref2$namespaceSepara,
       _ref2$preloadedState = _ref2.preloadedState,
       preloadedState = _ref2$preloadedState === undefined ? {} : _ref2$preloadedState,
       _ref2$disableWarnings = _ref2.disableWarnings,
@@ -316,6 +327,12 @@ function load() {
     namespace = NAMESPACE_DEFAULT;
   }
 
+  // Validate 'namespaceSeparator' parameter
+  if (!isString(namespaceSeparator)) {
+    console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'load()' method was passed a non-string value. Setting default value instead. Check your 'load()' method.");
+    namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT;
+  }
+
   // Display immmutablejs deprecation notice if developer tries to utilise it
   if (immutablejs === true) {
     warn_('Support for Immutable.js data structures has been deprecated as of version 2.0.0. Please use version 1.4.0 if you require this functionality.');
@@ -331,10 +348,10 @@ function load() {
   } else {
     // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
-      if (localStorage.getItem(namespace + '_' + state)) {
-        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[namespace + '_' + state])));
+      if (localStorage.getItem(namespace + namespaceSeparator + state)) {
+        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[namespace + namespaceSeparator + state])));
       } else {
-        warn_("Invalid load '" + (namespace + '_' + state) + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
+        warn_("Invalid load '" + (namespace + namespaceSeparator + state) + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
       }
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import objectMerge from 'object-merge'
 
 const MODULE_NAME = '[Redux-LocalStorage-Simple]'
 const NAMESPACE_DEFAULT = 'redux_localstorage_simple'
+const NAMESPACE_SEPARATOR_DEFAULT = '_'
 const STATES_DEFAULT = []
 const DEBOUNCE_DEFAULT = 0
 const IMMUTABLEJS_DEFAULT = false
@@ -157,6 +158,7 @@ function realiseObject (objectPath, objectInitialValue = {}) {
 export function save ({
       states = STATES_DEFAULT,
       namespace = NAMESPACE_DEFAULT,
+      namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT,
       debounce = DEBOUNCE_DEFAULT
     } = {}) {
   return store => next => action => {
@@ -172,6 +174,12 @@ export function save ({
     if (!isString(namespace)) {
       console.error(MODULE_NAME, "'namespace' parameter in 'save()' method was passed a non-string value. Setting default value instead. Check your 'save()' method.")
       namespace = NAMESPACE_DEFAULT
+    }
+
+    // Validate 'namespaceSeparator' parameter
+    if (!isString(namespaceSeparator)) {
+      console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'load()' method was passed a non-string value. Setting default value instead. Check your 'load()' method.")
+      namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT
     }
 
     // Validate 'debounce' parameter
@@ -215,10 +223,10 @@ export function save ({
         states.forEach(state => {
           const stateForLocalStorage = getStateForLocalStorage(state, store.getState())
           if (stateForLocalStorage) {
-            localStorage[namespace + '_' + state] = JSON.stringify(stateForLocalStorage)
+            localStorage[namespace + namespaceSeparator + state] = JSON.stringify(stateForLocalStorage)
           } else {
             // Make sure nothing is ever saved for this incorrect state
-            localStorage.removeItem(namespace + '_' + state)
+            localStorage.removeItem(namespace + namespaceSeparator + state)
           }
         })
       }
@@ -265,6 +273,7 @@ export function load ({
       states = STATES_DEFAULT,
       immutablejs = IMMUTABLEJS_DEFAULT,
       namespace = NAMESPACE_DEFAULT,
+      namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT,
       preloadedState = {},
       disableWarnings = DISABLE_WARNINGS_DEFAULT
     } = {}) {
@@ -283,6 +292,12 @@ export function load ({
     namespace = NAMESPACE_DEFAULT
   }
 
+  // Validate 'namespaceSeparator' parameter
+  if (!isString(namespaceSeparator)) {
+    console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'load()' method was passed a non-string value. Setting default value instead. Check your 'load()' method.")
+    namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT
+  }
+
   // Display immmutablejs deprecation notice if developer tries to utilise it
   if (immutablejs === true) {
     warn_('Support for Immutable.js data structures has been deprecated as of version 2.0.0. Please use version 1.4.0 if you require this functionality.')
@@ -297,10 +312,10 @@ export function load ({
     }
   } else { // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
-      if (localStorage.getItem(namespace + '_' + state)) {
-        loadedState = objectMerge(loadedState, realiseObject(state, JSON.parse(localStorage[namespace + '_' + state])))
+      if (localStorage.getItem(namespace + namespaceSeparator + state)) {
+        loadedState = objectMerge(loadedState, realiseObject(state, JSON.parse(localStorage[namespace + namespaceSeparator + state])))
       } else {
-        warn_("Invalid load '" + (namespace + '_' + state) + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.")
+        warn_("Invalid load '" + (namespace + namespaceSeparator + state) + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.")
       }
     })
   }

--- a/test/test.html
+++ b/test/test.html
@@ -19,10 +19,12 @@
 			<p><strong>Test 2</strong>: Save and load <u>part</u> of Redux state tree: <span id="test2"></span></p>
 			<p><strong>Test 3</strong>: Save and load <u>entire</u> Redux state tree under a specified <u>namespace</u>: <span id="test3"></span></p>
 			<p><strong>Test 4</strong>: Save and load <u>part</u> of Redux state tree under a specified <u>namespace</u>: <span id="test4"></span></p>
-			<p><strong>Test 5</strong>: Clear Redux state tree data saved with the <u>default namespace</u>: <span id="test7"></span></p>
-			<p><strong>Test 6</strong>: Clear Redux state tree data saved with a <u>specific namespace</u>: <span id="test8"></span></p>
-			<p><strong>Test 7</strong>: Save Redux state with <u>debouncing</u>: <span id="test9"></span></p>
-			<p><strong>Test 8</strong>: Save and load specific properties of a <u>part</u> of Redux state tree under a specified <u>namespace</u>: <span id="test10"></span></p>
+			<p><strong>Test 5</strong>: Save and load <u>entire</u> Redux state tree under a specified <u>namespace</u> with a specific <u>namespaceSeparator</u>: <span id="test5"></span></p>
+			<p><strong>Test 6</strong>: Save and load <u>part</u> of Redux state tree under a specified <u>namespace</u> with a specific <u>namespaceSeparator</u>: <span id="test6"></span></p>
+			<p><strong>Test 7</strong>: Clear Redux state tree data saved with the <u>default namespace</u>: <span id="test7"></span></p>
+			<p><strong>Test 8</strong>: Clear Redux state tree data saved with a <u>specific namespace</u>: <span id="test8"></span></p>
+			<p><strong>Test 9</strong>: Save Redux state with <u>debouncing</u>: <span id="test9"></span></p>
+			<p><strong>Test 10</strong>: Save and load specific properties of a <u>part</u> of Redux state tree under a specified <u>namespace</u>: <span id="test10"></span></p>
 		</div>
 		<script src="test.js"></script>
 	</body>

--- a/test/test.js
+++ b/test/test.js
@@ -68,6 +68,7 @@
 
 	var NAMESPACE_DEFAULT = 'redux_localstorage_simple';
 	var NAMESPACE_TEST = 'namespace_test';
+	var NAMESPACE_SEPARATOR_TEST = '**';
 
 	// -------------------------------------------------------------------------------
 
@@ -259,21 +260,65 @@
 	  outputTestResult('test4', _testResult3);
 	}
 
+	// -------------------------------------------------------------------------------------------------
+	// TEST 5 - Save and load entire Redux state tree under a specified namespace and namespaceSeparator
+	// -------------------------------------------------------------------------------------------------
+	clearTestData();
+
+	{
+	  var _middleware4 = (0, _index.save)({ namespace: NAMESPACE_TEST, namespaceSeparator: NAMESPACE_SEPARATOR_TEST });
+
+	  // Store which saves to LocalStorage
+	  var _storeA4 = (0, _redux.applyMiddleware)(_middleware4)(_redux.createStore)((0, _redux.combineReducers)({ reducerA: reducerA, reducerB: reducerB }), initialStateReducers);
+
+	  // Trigger a save to LocalStorage using a noop action
+	  _storeA4.dispatch({ type: NOOP });
+
+	  // Store which loads from LocalStorage
+	  var _storeB4 = (0, _redux.createStore)((0, _redux.combineReducers)({ reducerA: reducerA, reducerB: reducerB }), (0, _index.load)({ namespace: NAMESPACE_TEST, namespaceSeparator: NAMESPACE_SEPARATOR_TEST }));
+
+	  var _testResult4 = (0, _deepEqual2.default)(_storeA4.getState(), _storeB4.getState());
+
+	  outputTestResult('test5', _testResult4);
+	}
+
+	// ------------------------------------------------------------------------------------------------------
+	// TEST 6 - Save and load part of the Redux state tree under a specified namespace and namespaceSeparator
+	// ------------------------------------------------------------------------------------------------------
+	clearTestData();
+
+	{
+	  var _middleware5 = (0, _index.save)({ states: ['reducerA'], namespace: NAMESPACE_TEST, namespaceSeparator: NAMESPACE_SEPARATOR_TEST });
+
+	  // Store which saves to LocalStorage
+	  var _storeA5 = (0, _redux.applyMiddleware)(_middleware5)(_redux.createStore)((0, _redux.combineReducers)({ reducerA: reducerA, reducerB: reducerB }), initialStateReducers);
+
+	  // Trigger a save to LocalStorage using an append action
+	  _storeA5.dispatch({ type: APPEND });
+
+	  // Store which loads from LocalStorage
+	  var _storeB5 = (0, _redux.createStore)((0, _redux.combineReducers)({ reducerA: reducerA, reducerB: reducerB }), (0, _index.load)({ states: ['reducerA'], namespace: NAMESPACE_TEST, namespaceSeparator: NAMESPACE_SEPARATOR_TEST }));
+
+	  var _testResult5 = (0, _deepEqual2.default)(_storeA5.getState(), _storeB5.getState());
+
+	  outputTestResult('test6', _testResult5);
+	}
+
 	// -------------------------------------------------------------------------------
-	// TEST 5 - Clear Redux state tree data saved without a specific namespace
+	// TEST 7 - Clear Redux state tree data saved without a specific namespace
 	// -------------------------------------------------------------------------------
 	clearTestData();
 
 	{
 	  // Store that saves without a namespace
-	  var _storeA4 = (0, _redux.applyMiddleware)((0, _index.save)())(_redux.createStore)(reducerA, initialStateReducerA);
+	  var _storeA6 = (0, _redux.applyMiddleware)((0, _index.save)())(_redux.createStore)(reducerA, initialStateReducerA);
 	  // Trigger a save to LocalStorage using a noop action
-	  _storeA4.dispatch({ type: NOOP });
+	  _storeA6.dispatch({ type: NOOP });
 
 	  // Store that saves WITH a namespace
-	  var _storeB4 = (0, _redux.applyMiddleware)((0, _index.save)({ namespace: NAMESPACE_TEST }))(_redux.createStore)(reducerA, initialStateReducerA);
+	  var _storeB6 = (0, _redux.applyMiddleware)((0, _index.save)({ namespace: NAMESPACE_TEST }))(_redux.createStore)(reducerA, initialStateReducerA);
 	  // Trigger a save to LocalStorage using a noop action
-	  _storeB4.dispatch({ type: NOOP });
+	  _storeB6.dispatch({ type: NOOP });
 
 	  // Perform the LocalStorage clearing
 	  (0, _index.clear)();
@@ -289,20 +334,20 @@
 	}
 
 	// -------------------------------------------------------------------------------
-	// TEST 6 - Clear Redux state tree data saved with a specific namespace
+	// TEST 8 - Clear Redux state tree data saved with a specific namespace
 	// -------------------------------------------------------------------------------
 	clearTestData();
 
 	{
 	  // Store that saves without a namespace
-	  var _storeA5 = (0, _redux.applyMiddleware)((0, _index.save)())(_redux.createStore)(reducerA, initialStateReducerA);
+	  var _storeA7 = (0, _redux.applyMiddleware)((0, _index.save)())(_redux.createStore)(reducerA, initialStateReducerA);
 	  // Trigger a save to LocalStorage using a noop action
-	  _storeA5.dispatch({ type: NOOP });
+	  _storeA7.dispatch({ type: NOOP });
 
 	  // Store that saves WITH a namespace
-	  var _storeB5 = (0, _redux.applyMiddleware)((0, _index.save)({ namespace: NAMESPACE_TEST }))(_redux.createStore)(reducerA, initialStateReducerA);
+	  var _storeB7 = (0, _redux.applyMiddleware)((0, _index.save)({ namespace: NAMESPACE_TEST }))(_redux.createStore)(reducerA, initialStateReducerA);
 	  // Trigger a save to LocalStorage using a noop action
-	  _storeB5.dispatch({ type: NOOP });
+	  _storeB7.dispatch({ type: NOOP });
 
 	  // Perform the LocalStorage clearing
 	  (0, _index.clear)({ namespace: NAMESPACE_TEST });
@@ -318,7 +363,7 @@
 	}
 
 	// -------------------------------------------------------------------------------
-	// TEST 7 - Save Redux state with debouncing
+	// TEST 9 - Save Redux state with debouncing
 	// -------------------------------------------------------------------------------
 
 	clearTestData();
@@ -327,16 +372,16 @@
 	  var debouncingPeriod = 500;
 
 	  // Store that saves with a debouncing period
-	  var _storeA6 = (0, _redux.applyMiddleware)((0, _index.save)({ debounce: debouncingPeriod }))(_redux.createStore)(reducerB, initialStateReducerB);
+	  var _storeA8 = (0, _redux.applyMiddleware)((0, _index.save)({ debounce: debouncingPeriod }))(_redux.createStore)(reducerB, initialStateReducerB);
 	  // Trigger a save to LocalStorage using an add action
-	  _storeA6.dispatch({ type: ADD });
+	  _storeA8.dispatch({ type: ADD });
 
 	  // Store which loads from LocalStorage
-	  var _storeB6 = (0, _redux.createStore)(reducerB, (0, _index.load)());
+	  var _storeB8 = (0, _redux.createStore)(reducerB, (0, _index.load)());
 	  // This test result should fail because the debouncing period has
 	  // delayed the data being written to LocalStorage
-	  var _testResult4 = _storeB6.getState()['y'] === 1;
-	  outputTestResult('test9', _testResult4);
+	  var _testResult6 = _storeB8.getState()['y'] === 1;
+	  outputTestResult('test9', _testResult6);
 
 	  // This timeout will recheck LocalStorage after a period longer than
 	  // our specified debouncing period. Therefore it will see the updated
@@ -353,7 +398,7 @@
 	}
 
 	// -------------------------------------------------------------------------------
-	// TEST 8 - Save and load specific properties of a <u>part</u> of Redux state tree under a specified <u>namespace</u>
+	// TEST 10 - Save and load specific properties of a <u>part</u> of Redux state tree under a specified <u>namespace</u>
 	// -------------------------------------------------------------------------------
 	clearTestData();
 
@@ -361,23 +406,23 @@
 
 	  var states = ['reducerMultipleLevels.setting1', 'reducerMultipleLevels.setting3.level1.level2'];
 
-	  var _middleware4 = (0, _index.save)({ states: states, namespace: NAMESPACE_TEST });
+	  var _middleware6 = (0, _index.save)({ states: states, namespace: NAMESPACE_TEST });
 
 	  // Store which saves to LocalStorage
-	  var _storeA7 = (0, _redux.applyMiddleware)(_middleware4)(_redux.createStore)((0, _redux.combineReducers)({ reducerMultipleLevels: reducerMultipleLevels }), initialStateReducersPlusMultipleLevels);
+	  var _storeA9 = (0, _redux.applyMiddleware)(_middleware6)(_redux.createStore)((0, _redux.combineReducers)({ reducerMultipleLevels: reducerMultipleLevels }), initialStateReducersPlusMultipleLevels);
 
-	  _storeA7.dispatch({ type: MODIFY });
+	  _storeA9.dispatch({ type: MODIFY });
 
 	  // Store which loads from LocalStorage
-	  var _storeB7 = (0, _redux.createStore)((0, _redux.combineReducers)({ reducerMultipleLevels: reducerMultipleLevels }), (0, _index.load)({
+	  var _storeB9 = (0, _redux.createStore)((0, _redux.combineReducers)({ reducerMultipleLevels: reducerMultipleLevels }), (0, _index.load)({
 	    states: states,
 	    namespace: NAMESPACE_TEST,
 	    preloadedState: initialStateReducersPlusMultipleLevels
 	  }));
 
-	  var _testResult5 = (0, _deepEqual2.default)(_storeA7.getState(), _storeB7.getState());
+	  var _testResult7 = (0, _deepEqual2.default)(_storeA9.getState(), _storeB9.getState());
 
-	  outputTestResult('test10', _testResult5);
+	  outputTestResult('test10', _testResult7);
 	}
 
 	// -------------------------------------------------------------------------------
@@ -1646,6 +1691,7 @@
 
 	var MODULE_NAME = '[Redux-LocalStorage-Simple]';
 	var NAMESPACE_DEFAULT = 'redux_localstorage_simple';
+	var NAMESPACE_SEPARATOR_DEFAULT = '_';
 	var STATES_DEFAULT = [];
 	var DEBOUNCE_DEFAULT = 0;
 	var IMMUTABLEJS_DEFAULT = false;
@@ -1804,6 +1850,8 @@
 	      states = _ref$states === undefined ? STATES_DEFAULT : _ref$states,
 	      _ref$namespace = _ref.namespace,
 	      namespace = _ref$namespace === undefined ? NAMESPACE_DEFAULT : _ref$namespace,
+	      _ref$namespaceSeparat = _ref.namespaceSeparator,
+	      namespaceSeparator = _ref$namespaceSeparat === undefined ? NAMESPACE_SEPARATOR_DEFAULT : _ref$namespaceSeparat,
 	      _ref$debounce = _ref.debounce,
 	      debounce = _ref$debounce === undefined ? DEBOUNCE_DEFAULT : _ref$debounce;
 
@@ -1822,6 +1870,12 @@
 	        if (!isString(namespace)) {
 	          console.error(MODULE_NAME, "'namespace' parameter in 'save()' method was passed a non-string value. Setting default value instead. Check your 'save()' method.");
 	          namespace = NAMESPACE_DEFAULT;
+	        }
+
+	        // Validate 'namespaceSeparator' parameter
+	        if (!isString(namespaceSeparator)) {
+	          console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'load()' method was passed a non-string value. Setting default value instead. Check your 'load()' method.");
+	          namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT;
 	        }
 
 	        // Validate 'debounce' parameter
@@ -1865,10 +1919,10 @@
 	            states.forEach(function (state) {
 	              var stateForLocalStorage = getStateForLocalStorage(state, store.getState());
 	              if (stateForLocalStorage) {
-	                localStorage[namespace + '_' + state] = JSON.stringify(stateForLocalStorage);
+	                localStorage[namespace + namespaceSeparator + state] = JSON.stringify(stateForLocalStorage);
 	              } else {
 	                // Make sure nothing is ever saved for this incorrect state
-	                localStorage.removeItem(namespace + '_' + state);
+	                localStorage.removeItem(namespace + namespaceSeparator + state);
 	              }
 	            });
 	          }
@@ -1921,6 +1975,8 @@
 	      immutablejs = _ref2$immutablejs === undefined ? IMMUTABLEJS_DEFAULT : _ref2$immutablejs,
 	      _ref2$namespace = _ref2.namespace,
 	      namespace = _ref2$namespace === undefined ? NAMESPACE_DEFAULT : _ref2$namespace,
+	      _ref2$namespaceSepara = _ref2.namespaceSeparator,
+	      namespaceSeparator = _ref2$namespaceSepara === undefined ? NAMESPACE_SEPARATOR_DEFAULT : _ref2$namespaceSepara,
 	      _ref2$preloadedState = _ref2.preloadedState,
 	      preloadedState = _ref2$preloadedState === undefined ? {} : _ref2$preloadedState,
 	      _ref2$disableWarnings = _ref2.disableWarnings,
@@ -1941,6 +1997,12 @@
 	    namespace = NAMESPACE_DEFAULT;
 	  }
 
+	  // Validate 'namespaceSeparator' parameter
+	  if (!isString(namespaceSeparator)) {
+	    console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'load()' method was passed a non-string value. Setting default value instead. Check your 'load()' method.");
+	    namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT;
+	  }
+
 	  // Display immmutablejs deprecation notice if developer tries to utilise it
 	  if (immutablejs === true) {
 	    warn_('Support for Immutable.js data structures has been deprecated as of version 2.0.0. Please use version 1.4.0 if you require this functionality.');
@@ -1956,10 +2018,10 @@
 	  } else {
 	    // Load only specified states into the local Redux state tree
 	    states.forEach(function (state) {
-	      if (localStorage.getItem(namespace + '_' + state)) {
-	        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[namespace + '_' + state])));
+	      if (localStorage.getItem(namespace + namespaceSeparator + state)) {
+	        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[namespace + namespaceSeparator + state])));
 	      } else {
-	        warn_("Invalid load '" + (namespace + '_' + state) + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
+	        warn_("Invalid load '" + (namespace + namespaceSeparator + state) + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
 	      }
 	    });
 	  }

--- a/test/test_.js
+++ b/test/test_.js
@@ -6,6 +6,7 @@ import equal from 'deep-equal'
 
 const NAMESPACE_DEFAULT = 'redux_localstorage_simple'
 const NAMESPACE_TEST = 'namespace_test'
+const NAMESPACE_SEPARATOR_TEST = '**'
 
 // -------------------------------------------------------------------------------
 
@@ -225,8 +226,70 @@ clearTestData()
   outputTestResult('test4', testResult)
 }
 
+// -------------------------------------------------------------------------------------------------
+// TEST 5 - Save and load entire Redux state tree under a specified namespace and namespaceSeparator
+// -------------------------------------------------------------------------------------------------
+clearTestData()
+
+{
+  let middleware = save({ namespace: NAMESPACE_TEST, namespaceSeparator: NAMESPACE_SEPARATOR_TEST })
+
+  // Store which saves to LocalStorage
+  let storeA = applyMiddleware(middleware)(createStore)(
+    combineReducers({ reducerA, reducerB }),
+    initialStateReducers
+  )
+
+  // Trigger a save to LocalStorage using a noop action
+  storeA.dispatch({ type: NOOP })
+
+  // Store which loads from LocalStorage
+  let storeB = createStore(
+    combineReducers({ reducerA, reducerB }),
+    load({ namespace: NAMESPACE_TEST, namespaceSeparator: NAMESPACE_SEPARATOR_TEST })
+  )
+
+  let testResult = equal(
+    storeA.getState(),
+    storeB.getState()
+  )
+
+  outputTestResult('test5', testResult)
+}
+
+// ------------------------------------------------------------------------------------------------------
+// TEST 6 - Save and load part of the Redux state tree under a specified namespace and namespaceSeparator
+// ------------------------------------------------------------------------------------------------------
+clearTestData()
+
+{
+  let middleware = save({ states: ['reducerA'], namespace: NAMESPACE_TEST, namespaceSeparator: NAMESPACE_SEPARATOR_TEST })
+
+  // Store which saves to LocalStorage
+  let storeA = applyMiddleware(middleware)(createStore)(
+    combineReducers({ reducerA, reducerB }),
+    initialStateReducers
+  )
+
+  // Trigger a save to LocalStorage using an append action
+  storeA.dispatch({ type: APPEND })
+
+  // Store which loads from LocalStorage
+  let storeB = createStore(
+    combineReducers({ reducerA, reducerB }),
+    load({ states: ['reducerA'], namespace: NAMESPACE_TEST, namespaceSeparator: NAMESPACE_SEPARATOR_TEST })
+  )
+
+  let testResult = equal(
+    storeA.getState(),
+    storeB.getState()
+  )
+
+  outputTestResult('test6', testResult)
+}
+
 // -------------------------------------------------------------------------------
-// TEST 5 - Clear Redux state tree data saved without a specific namespace
+// TEST 7 - Clear Redux state tree data saved without a specific namespace
 // -------------------------------------------------------------------------------
 clearTestData()
 
@@ -255,7 +318,7 @@ clearTestData()
 }
 
 // -------------------------------------------------------------------------------
-// TEST 6 - Clear Redux state tree data saved with a specific namespace
+// TEST 8 - Clear Redux state tree data saved with a specific namespace
 // -------------------------------------------------------------------------------
 clearTestData()
 
@@ -284,7 +347,7 @@ clearTestData()
 }
 
 // -------------------------------------------------------------------------------
-// TEST 7 - Save Redux state with debouncing
+// TEST 9 - Save Redux state with debouncing
 // -------------------------------------------------------------------------------
 
 clearTestData()
@@ -319,7 +382,7 @@ clearTestData()
 }
 
 // -------------------------------------------------------------------------------
-// TEST 8 - Save and load specific properties of a <u>part</u> of Redux state tree under a specified <u>namespace</u>
+// TEST 10 - Save and load specific properties of a <u>part</u> of Redux state tree under a specified <u>namespace</u>
 // -------------------------------------------------------------------------------
 clearTestData()
 


### PR DESCRIPTION
This adds a new `namespaceSeparator` option that can be passed to both `save` and `load` functions, and allows to customize the string set between the namespace and the state key when saving a value to the local storage.

This will ease adopting this library in projects already using the local storage with other solutions or custom implementations, without having to break BC.

The use would be ase follows:

```js
save({
  namespace: 'my_namespace',
  namespaceSeparator: '::'
});

load({
  namespace: 'my_namespace',
  namespaceSeparator: '::'
});
```

If the `namespaceSeparator` is not provided, it will fall back to the `_` character, keeping the behavior the library had so far.

Closes #42 