### PR TITLE
Fix copy/paste error in validation error string

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -227,7 +227,7 @@ function save() {
 
         // Validate 'namespaceSeparator' parameter
         if (!isString(namespaceSeparator)) {
-          console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'load()' method was passed a non-string value. Setting default value instead. Check your 'load()' method.");
+          console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'save()' method was passed a non-string value. Setting default value instead. Check your 'save()' method.");
           namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT;
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ export function save ({
 
     // Validate 'namespaceSeparator' parameter
     if (!isString(namespaceSeparator)) {
-      console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'load()' method was passed a non-string value. Setting default value instead. Check your 'load()' method.")
+      console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'save()' method was passed a non-string value. Setting default value instead. Check your 'save()' method.")
       namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1942,7 +1942,7 @@
 
 	        // Validate 'namespaceSeparator' parameter
 	        if (!isString(namespaceSeparator)) {
-	          console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'load()' method was passed a non-string value. Setting default value instead. Check your 'load()' method.");
+	          console.error(MODULE_NAME, "'namespaceSeparator' parameter in 'save()' method was passed a non-string value. Setting default value instead. Check your 'save()' method.");
 	          namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT;
 	        }
 


### PR DESCRIPTION
This PR just fixes the `namespaceSeparator` validation error string that was copied from `load()` into `save()` without being updated.