### PR TITLE
Fix missing namespaceSeparator in LoadOptions type

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -11,14 +11,15 @@ declare module 'redux-localstorage-simple' {
   }
   interface LoadOptions {
     states?: string[];
-    namespace?: string;
     immutablejs?: boolean;
+    namespace?: string;
+    namespaceSeparator?: string;
     preloadedState?: {};
     disableWarnings?: boolean;
   }
   interface ClearOptions {
     namespace?: string;
-  }  
+  }
   export function save(options?:RLSOptions):Middleware
   export function load(options?:LoadOptions):object
   export function clear(options?:ClearOptions):void


### PR DESCRIPTION
`namespaceSeparator` was missing from `LoadOptions` although being supported by `load()`.

This PR fixes that, and also bumps `immutablejs` up so the order matches the parameter list in the `load()` implementation.