### PR TITLE
Refactor and trap localStorage and JSON parsing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ The `save` method takes a optional configuration object as an argument. It has t
     [Array ignoreStates]
     [String namespace],
     [String namespaceSeparator],
-    [Number debounce]
+    [Number debounce],
+    [Boolean disableWarnings]
 }
 ```
 
@@ -66,6 +67,7 @@ The `save` method takes a optional configuration object as an argument. It has t
 - namespace (String, optional) - This is an optional string specifying the namespace to add to your LocalStorage items. For example if you have a part of your Redux state tree called "user" and you specify the namespace "my_cool_app", it will be saved to LocalStorage as "my_cool_app_user"
 - namespaceSeparator (String, optional) - This is an optional string specifying the separator used between the namespace and the state keys. For example with the namespaceSeparator set to "::", the key saved to the LocalStorage would be "my_cool_app::user"
 - debounce (Number, optional) - Debouncing period (in milliseconds) to wait before saving to LocalStorage. Use this as a performance optimization if you feel you are saving to LocalStorage too often. Recommended value: 500 - 1000 milliseconds
+- disableWarnings (Boolean, optional) - Any exceptions thrown by LocalStorage will be logged as warnings in the JavaScript console by default, but can be silenced by setting `disableWarnings` to true.
 
 #### Examples
 
@@ -144,7 +146,7 @@ The `load` method takes a optional configuration object as an argument. It has t
 - namespace (String, optional) - If you have saved your entire state tree or parts of your state tree with a namespace you will need to specify it in order to load it from LocalStorage.
 - namespaceSeparator (String, optional) - If you have saved entire state tree or parts of your state tree with a namespaceSeparator, you will need to specify it in order to load it from LocalStorage.
 - preloadedState (Object, optional) - Passthrough for the `preloadedState` argument in Redux's `createStore` method. See section **Advanced Usage** below.
-- disableWarnings (Boolean, optional) - When you first try to a load a state from LocalStorage you will see a warning in the JavaScript console informing you that this state load is invalid. This is because the `save` method hasn't been called yet and this state has yet to been written to LocalStorage. You may not care to see this warning so to disable it set `disableWarnings` to true.
+- disableWarnings (Boolean, optional) - When you first try to a load a state from LocalStorage you will see a warning in the JavaScript console informing you that this state load is invalid. This is because the `save` method hasn't been called yet and this state has yet to been written to LocalStorage. You may not care to see this warning so to disable it set `disableWarnings` to true. Any exceptions thrown by LocalStorage will also be logged as warnings by default, but can be silenced by setting `disableWarnings` to true.
 
 #### Examples
 
@@ -221,11 +223,13 @@ The `clear` method takes a optional configuration object as an argument. It has 
 
 ```
 {
-    [String namespace]
+    [String namespace],
+    [Boolean disableWarnings]
 }
 ```
 
 - namespace - If you have saved your entire state tree or parts of your state tree under a namespace you will need to specify it in order to clear that data from LocalStorage.
+- disableWarnings (Boolean, optional) - Any exceptions thrown by LocalStorage will be logged as warnings in the JavaScript console by default, but can be silenced by setting `disableWarnings` to true.
 
 #### Examples
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -8,6 +8,7 @@ declare module 'redux-localstorage-simple' {
     namespace?: string;
     namespaceSeparator?: string;
     debounce?: number;
+    disableWarnings?: boolean;
   }
   interface LoadOptions {
     states?: string[];
@@ -18,7 +19,8 @@ declare module 'redux-localstorage-simple' {
   }
   interface ClearOptions {
     namespace?: string;
-  }  
+    disableWarnings?: boolean;
+  }
   export function save(options?:RLSOptions):Middleware
   export function load(options?:LoadOptions):object
   export function clear(options?:ClearOptions):void

--- a/dist/index.js
+++ b/dist/index.js
@@ -373,15 +373,17 @@ function load() {
 
   // Load all of the namespaced Redux data from LocalStorage into local Redux state tree
   if (states.length === 0) {
-    if (localStorage.getItem(namespace)) {
-      loadedState = JSON.parse(localStorage.getItem(namespace));
+    var val = localStorage.getItem(namespace);
+    if (val) {
+      loadedState = JSON.parse(val);
     }
   } else {
     // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
       var key = namespace + namespaceSeparator + state;
-      if (localStorage.getItem(key)) {
-        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage.getItem(key))));
+      var val = localStorage.getItem(key);
+      if (val) {
+        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(val)));
       } else {
         warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -274,13 +274,13 @@ function save() {
         // Local function to avoid duplication of code above
         function _save() {
           if (states.length === 0) {
-            localStorage[namespace] = JSON.stringify(state_);
+            localStorage.setItem(namespace, JSON.stringify(state_));
           } else {
             states.forEach(function (state) {
               var key = namespace + namespaceSeparator + state;
               var stateForLocalStorage = getStateForLocalStorage(state, state_);
               if (stateForLocalStorage) {
-                localStorage[key] = JSON.stringify(stateForLocalStorage);
+                localStorage.setItem(key, JSON.stringify(stateForLocalStorage));
               } else {
                 // Make sure nothing is ever saved for this incorrect state
                 localStorage.removeItem(key);
@@ -373,15 +373,15 @@ function load() {
 
   // Load all of the namespaced Redux data from LocalStorage into local Redux state tree
   if (states.length === 0) {
-    if (localStorage[namespace]) {
-      loadedState = JSON.parse(localStorage[namespace]);
+    if (localStorage.getItem(namespace)) {
+      loadedState = JSON.parse(localStorage.getItem(namespace));
     }
   } else {
     // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
       var key = namespace + namespaceSeparator + state;
       if (localStorage.getItem(key)) {
-        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[key])));
+        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage.getItem(key))));
       } else {
         warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
       }
@@ -462,7 +462,10 @@ function clear() {
     namespace = NAMESPACE_DEFAULT;
   }
 
-  for (var key in localStorage) {
+  var len = localStorage.length;
+  for (var ind = 0; ind < len; ind++) {
+    var key = localStorage.key(ind);
+
     // key starts with namespace
     if (key.slice(0, namespace.length) === namespace) {
       localStorage.removeItem(key);

--- a/dist/index.js
+++ b/dist/index.js
@@ -277,12 +277,13 @@ function save() {
             localStorage[namespace] = JSON.stringify(state_);
           } else {
             states.forEach(function (state) {
+              var key = namespace + namespaceSeparator + state;
               var stateForLocalStorage = getStateForLocalStorage(state, state_);
               if (stateForLocalStorage) {
-                localStorage[namespace + namespaceSeparator + state] = JSON.stringify(stateForLocalStorage);
+                localStorage[key] = JSON.stringify(stateForLocalStorage);
               } else {
                 // Make sure nothing is ever saved for this incorrect state
-                localStorage.removeItem(namespace + namespaceSeparator + state);
+                localStorage.removeItem(key);
               }
             });
           }
@@ -378,10 +379,11 @@ function load() {
   } else {
     // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
-      if (localStorage.getItem(namespace + namespaceSeparator + state)) {
-        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[namespace + namespaceSeparator + state])));
+      var key = namespace + namespaceSeparator + state;
+      if (localStorage.getItem(key)) {
+        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[key])));
       } else {
-        warn_("Invalid load '" + (namespace + namespaceSeparator + state) + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
+        warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
       }
     });
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,13 +45,17 @@ var debounceTimeout = null;
 
 */
 
-function warn(disableWarnings) {
-  return function (warningMessage) {
-    if (!disableWarnings) {
-      console.warn(MODULE_NAME, warningMessage);
-    }
-  };
+function warnConsole(warningMessage) {
+  console.warn(MODULE_NAME, warningMessage);
 }
+
+function warnSilent(_warningMessage) {
+  // Empty
+}
+
+var warn = function warn(disableWarnings) {
+  return disableWarnings ? warnSilent : warnConsole;
+};
 
 // ---------------------------------------------------
 /* lensPath

--- a/dist/index.js
+++ b/dist/index.js
@@ -135,6 +135,61 @@ function realiseObject(objectPath) {
 }
 
 // ---------------------------------------------------
+// SafeLocalStorage wrapper to handle the minefield of exceptions
+// that localStorage can throw. JSON.parse() is handled here as well.
+
+function SafeLocalStorage(warnFn) {
+  this.warnFn = warnFn || warnConsole;
+}
+
+Object.defineProperty(SafeLocalStorage.prototype, 'length', {
+  get: function length() {
+    try {
+      return localStorage.length;
+    } catch (err) {
+      this.warnFn(err);
+    }
+    return 0;
+  },
+  configurable: true,
+  enumerable: true
+});
+
+SafeLocalStorage.prototype.key = function key(ind) {
+  try {
+    return localStorage.key(ind);
+  } catch (err) {
+    this.warnFn(err);
+  }
+  return null;
+};
+
+SafeLocalStorage.prototype.setItem = function setItem(key, val) {
+  try {
+    localStorage.setItem(key, JSON.stringify(val));
+  } catch (err) {
+    this.warnFn(err);
+  }
+};
+
+SafeLocalStorage.prototype.getItem = function getItem(key) {
+  try {
+    return JSON.parse(localStorage.getItem(key));
+  } catch (err) {
+    this.warnFn(err);
+  }
+  return null;
+};
+
+SafeLocalStorage.prototype.removeItem = function removeItem(key) {
+  try {
+    localStorage.removeItem(key);
+  } catch (err) {
+    this.warnFn(err);
+  }
+};
+
+// ---------------------------------------------------
 
 /**
   Saves specified parts of the Redux state tree into localstorage
@@ -192,11 +247,16 @@ function save() {
       _ref$namespaceSeparat = _ref.namespaceSeparator,
       namespaceSeparator = _ref$namespaceSeparat === undefined ? NAMESPACE_SEPARATOR_DEFAULT : _ref$namespaceSeparat,
       _ref$debounce = _ref.debounce,
-      debounce = _ref$debounce === undefined ? DEBOUNCE_DEFAULT : _ref$debounce;
+      debounce = _ref$debounce === undefined ? DEBOUNCE_DEFAULT : _ref$debounce,
+      _ref$disableWarnings = _ref.disableWarnings,
+      disableWarnings = _ref$disableWarnings === undefined ? DISABLE_WARNINGS_DEFAULT : _ref$disableWarnings;
 
   return function (store) {
     return function (next) {
       return function (action) {
+        // Bake disableWarnings into the warn function
+        var warn_ = warn(disableWarnings);
+
         var returnValue = next(action);
         var state_ = void 0;
 
@@ -248,6 +308,8 @@ function save() {
           state_ = store.getState();
         }
 
+        var storage = new SafeLocalStorage(warn_);
+
         // Check to see whether to debounce LocalStorage saving
         if (debounce) {
           // Clear the debounce timeout if it was previously set
@@ -278,16 +340,16 @@ function save() {
         // Local function to avoid duplication of code above
         function _save() {
           if (states.length === 0) {
-            localStorage.setItem(namespace, JSON.stringify(state_));
+            storage.setItem(namespace, state_);
           } else {
             states.forEach(function (state) {
               var key = namespace + namespaceSeparator + state;
               var stateForLocalStorage = getStateForLocalStorage(state, state_);
               if (stateForLocalStorage) {
-                localStorage.setItem(key, JSON.stringify(stateForLocalStorage));
+                storage.setItem(key, stateForLocalStorage);
               } else {
                 // Make sure nothing is ever saved for this incorrect state
-                localStorage.removeItem(key);
+                storage.removeItem(key);
               }
             });
           }
@@ -373,21 +435,23 @@ function load() {
     warn_('Support for Immutable.js data structures has been deprecated as of version 2.0.0. Please use version 1.4.0 if you require this functionality.');
   }
 
+  var storage = new SafeLocalStorage(warn_);
+
   var loadedState = preloadedState;
 
   // Load all of the namespaced Redux data from LocalStorage into local Redux state tree
   if (states.length === 0) {
-    var val = localStorage.getItem(namespace);
+    var val = storage.getItem(namespace);
     if (val) {
-      loadedState = JSON.parse(val);
+      loadedState = val;
     }
   } else {
     // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
       var key = namespace + namespaceSeparator + state;
-      var val = localStorage.getItem(key);
+      var val = storage.getItem(key);
       if (val) {
-        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(val)));
+        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, val));
       } else {
         warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
       }
@@ -460,7 +524,12 @@ function combineLoads() {
 function clear() {
   var _ref3 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
       _ref3$namespace = _ref3.namespace,
-      namespace = _ref3$namespace === undefined ? NAMESPACE_DEFAULT : _ref3$namespace;
+      namespace = _ref3$namespace === undefined ? NAMESPACE_DEFAULT : _ref3$namespace,
+      _ref3$disableWarnings = _ref3.disableWarnings,
+      disableWarnings = _ref3$disableWarnings === undefined ? DISABLE_WARNINGS_DEFAULT : _ref3$disableWarnings;
+
+  // Bake disableWarnings into the warn function
+  var warn_ = warn(disableWarnings);
 
   // Validate 'namespace' parameter
   if (!isString(namespace)) {
@@ -468,13 +537,15 @@ function clear() {
     namespace = NAMESPACE_DEFAULT;
   }
 
-  var len = localStorage.length;
+  var storage = new SafeLocalStorage(warn_);
+
+  var len = storage.length;
   for (var ind = 0; ind < len; ind++) {
-    var key = localStorage.key(ind);
+    var key = storage.key(ind);
 
     // key starts with namespace
-    if (key.slice(0, namespace.length) === namespace) {
-      localStorage.removeItem(key);
+    if (key && key.slice(0, namespace.length) === namespace) {
+      storage.removeItem(key);
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -335,14 +335,16 @@ export function load ({
 
   // Load all of the namespaced Redux data from LocalStorage into local Redux state tree
   if (states.length === 0) {
-    if (localStorage.getItem(namespace)) {
-      loadedState = JSON.parse(localStorage.getItem(namespace))
+    const val = localStorage.getItem(namespace)
+    if (val) {
+      loadedState = JSON.parse(val)
     }
   } else { // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
       const key = namespace + namespaceSeparator + state
-      if (localStorage.getItem(key)) {
-        loadedState = objectMerge(loadedState, realiseObject(state, JSON.parse(localStorage.getItem(key))))
+      const val = localStorage.getItem(key)
+      if (val) {
+        loadedState = objectMerge(loadedState, realiseObject(state, JSON.parse(val)))
       } else {
         warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.")
       }

--- a/src/index.js
+++ b/src/index.js
@@ -248,12 +248,13 @@ export function save ({
         localStorage[namespace] = JSON.stringify(state_)
       } else {
         states.forEach(state => {
+          const key = namespace + namespaceSeparator + state
           const stateForLocalStorage = getStateForLocalStorage(state, state_)
           if (stateForLocalStorage) {
-            localStorage[namespace + namespaceSeparator + state] = JSON.stringify(stateForLocalStorage)
+            localStorage[key] = JSON.stringify(stateForLocalStorage)
           } else {
             // Make sure nothing is ever saved for this incorrect state
-            localStorage.removeItem(namespace + namespaceSeparator + state)
+            localStorage.removeItem(key)
           }
         })
       }
@@ -339,10 +340,11 @@ export function load ({
     }
   } else { // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
-      if (localStorage.getItem(namespace + namespaceSeparator + state)) {
-        loadedState = objectMerge(loadedState, realiseObject(state, JSON.parse(localStorage[namespace + namespaceSeparator + state])))
+      const key = namespace + namespaceSeparator + state
+      if (localStorage.getItem(key)) {
+        loadedState = objectMerge(loadedState, realiseObject(state, JSON.parse(localStorage[key])))
       } else {
-        warn_("Invalid load '" + (namespace + namespaceSeparator + state) + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.")
+        warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.")
       }
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -245,13 +245,13 @@ export function save ({
     // Local function to avoid duplication of code above
     function _save () {
       if (states.length === 0) {
-        localStorage[namespace] = JSON.stringify(state_)
+        localStorage.setItem(namespace, JSON.stringify(state_))
       } else {
         states.forEach(state => {
           const key = namespace + namespaceSeparator + state
           const stateForLocalStorage = getStateForLocalStorage(state, state_)
           if (stateForLocalStorage) {
-            localStorage[key] = JSON.stringify(stateForLocalStorage)
+            localStorage.setItem(key, JSON.stringify(stateForLocalStorage))
           } else {
             // Make sure nothing is ever saved for this incorrect state
             localStorage.removeItem(key)
@@ -335,14 +335,14 @@ export function load ({
 
   // Load all of the namespaced Redux data from LocalStorage into local Redux state tree
   if (states.length === 0) {
-    if (localStorage[namespace]) {
-      loadedState = JSON.parse(localStorage[namespace])
+    if (localStorage.getItem(namespace)) {
+      loadedState = JSON.parse(localStorage.getItem(namespace))
     }
   } else { // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
       const key = namespace + namespaceSeparator + state
       if (localStorage.getItem(key)) {
-        loadedState = objectMerge(loadedState, realiseObject(state, JSON.parse(localStorage[key])))
+        loadedState = objectMerge(loadedState, realiseObject(state, JSON.parse(localStorage.getItem(key))))
       } else {
         warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.")
       }
@@ -415,7 +415,10 @@ export function clear ({ namespace = NAMESPACE_DEFAULT } = {}) {
     namespace = NAMESPACE_DEFAULT
   }
 
-  for (let key in localStorage) {
+  const len = localStorage.length
+  for (let ind = 0; ind < len; ind++) {
+    const key = localStorage.key(ind)
+
     // key starts with namespace
     if (key.slice(0, namespace.length) === namespace) {
       localStorage.removeItem(key)

--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,61 @@ function realiseObject (objectPath, objectInitialValue = {}) {
 }
 
 // ---------------------------------------------------
+// SafeLocalStorage wrapper to handle the minefield of exceptions
+// that localStorage can throw. JSON.parse() is handled here as well.
+
+function SafeLocalStorage (warnFn) {
+  this.warnFn = warnFn || warnConsole
+}
+
+Object.defineProperty(SafeLocalStorage.prototype, 'length', {
+  get: function length () {
+    try {
+      return localStorage.length
+    } catch (err) {
+      this.warnFn(err)
+    }
+    return 0
+  },
+  configurable: true,
+  enumerable: true
+});
+
+SafeLocalStorage.prototype.key = function key (ind) {
+  try {
+    return localStorage.key(ind)
+  } catch (err) {
+    this.warnFn(err)
+  }
+  return null
+}
+
+SafeLocalStorage.prototype.setItem = function setItem (key, val) {
+  try {
+    localStorage.setItem(key, JSON.stringify(val))
+  } catch (err) {
+    this.warnFn(err)
+  }
+}
+
+SafeLocalStorage.prototype.getItem = function getItem (key) {
+  try {
+    return JSON.parse(localStorage.getItem(key))
+  } catch (err) {
+    this.warnFn(err)
+  }
+  return null
+}
+
+SafeLocalStorage.prototype.removeItem = function removeItem (key) {
+  try {
+    localStorage.removeItem(key)
+  } catch (err) {
+    this.warnFn(err)
+  }
+}
+
+// ---------------------------------------------------
 
 /**
   Saves specified parts of the Redux state tree into localstorage
@@ -163,9 +218,13 @@ export function save ({
       ignoreStates = IGNORE_STATES_DEFAULT,
       namespace = NAMESPACE_DEFAULT,
       namespaceSeparator = NAMESPACE_SEPARATOR_DEFAULT,
-      debounce = DEBOUNCE_DEFAULT
+      debounce = DEBOUNCE_DEFAULT,
+      disableWarnings = DISABLE_WARNINGS_DEFAULT
     } = {}) {
   return store => next => action => {
+    // Bake disableWarnings into the warn function
+    const warn_ = warn(disableWarnings)
+
     const returnValue = next(action)
     let state_
 
@@ -217,6 +276,8 @@ export function save ({
       state_= store.getState()
     }
 
+    const storage = new SafeLocalStorage(warn_)
+
     // Check to see whether to debounce LocalStorage saving
     if (debounce) {
       // Clear the debounce timeout if it was previously set
@@ -247,16 +308,16 @@ export function save ({
     // Local function to avoid duplication of code above
     function _save () {
       if (states.length === 0) {
-        localStorage.setItem(namespace, JSON.stringify(state_))
+        storage.setItem(namespace, state_)
       } else {
         states.forEach(state => {
           const key = namespace + namespaceSeparator + state
           const stateForLocalStorage = getStateForLocalStorage(state, state_)
           if (stateForLocalStorage) {
-            localStorage.setItem(key, JSON.stringify(stateForLocalStorage))
+            storage.setItem(key, stateForLocalStorage)
           } else {
             // Make sure nothing is ever saved for this incorrect state
-            localStorage.removeItem(key)
+            storage.removeItem(key)
           }
         })
       }
@@ -333,20 +394,22 @@ export function load ({
     warn_('Support for Immutable.js data structures has been deprecated as of version 2.0.0. Please use version 1.4.0 if you require this functionality.')
   }
 
+  const storage = new SafeLocalStorage(warn_)
+
   let loadedState = preloadedState
 
   // Load all of the namespaced Redux data from LocalStorage into local Redux state tree
   if (states.length === 0) {
-    const val = localStorage.getItem(namespace)
+    const val = storage.getItem(namespace)
     if (val) {
-      loadedState = JSON.parse(val)
+      loadedState = val
     }
   } else { // Load only specified states into the local Redux state tree
     states.forEach(function (state) {
       const key = namespace + namespaceSeparator + state
-      const val = localStorage.getItem(key)
+      const val = storage.getItem(key)
       if (val) {
-        loadedState = objectMerge(loadedState, realiseObject(state, JSON.parse(val)))
+        loadedState = objectMerge(loadedState, realiseObject(state, val))
       } else {
         warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.")
       }
@@ -412,20 +475,28 @@ export function combineLoads (...loads) {
     })
 */
 
-export function clear ({ namespace = NAMESPACE_DEFAULT } = {}) {
+export function clear ({
+  namespace = NAMESPACE_DEFAULT,
+  disableWarnings = DISABLE_WARNINGS_DEFAULT
+} = {}) {
+  // Bake disableWarnings into the warn function
+  const warn_ = warn(disableWarnings)
+
   // Validate 'namespace' parameter
   if (!isString(namespace)) {
     console.error(MODULE_NAME, "'namespace' parameter in 'clear()' method was passed a non-string value. Setting default value instead. Check your 'clear()' method.")
     namespace = NAMESPACE_DEFAULT
   }
 
-  const len = localStorage.length
+  const storage = new SafeLocalStorage(warn_)
+
+  const len = storage.length
   for (let ind = 0; ind < len; ind++) {
-    const key = localStorage.key(ind)
+    const key = storage.key(ind)
 
     // key starts with namespace
-    if (key.slice(0, namespace.length) === namespace) {
-      localStorage.removeItem(key)
+    if (key && key.slice(0, namespace.length) === namespace) {
+      storage.removeItem(key)
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -26,13 +26,15 @@ let debounceTimeout = null
 
 */
 
-function warn (disableWarnings) {
-  return function (warningMessage) {
-    if (!disableWarnings) {
-      console.warn(MODULE_NAME, warningMessage)
-    }
-  }
+function warnConsole (warningMessage) {
+  console.warn(MODULE_NAME, warningMessage)
 }
+
+function warnSilent (_warningMessage) {
+  // Empty
+}
+
+const warn = disableWarnings => (disableWarnings ? warnSilent : warnConsole)
 
 // ---------------------------------------------------
 /* lensPath

--- a/test/test.js
+++ b/test/test.js
@@ -2088,15 +2088,17 @@
 
 	  // Load all of the namespaced Redux data from LocalStorage into local Redux state tree
 	  if (states.length === 0) {
-	    if (localStorage.getItem(namespace)) {
-	      loadedState = JSON.parse(localStorage.getItem(namespace));
+	    var val = localStorage.getItem(namespace);
+	    if (val) {
+	      loadedState = JSON.parse(val);
 	    }
 	  } else {
 	    // Load only specified states into the local Redux state tree
 	    states.forEach(function (state) {
 	      var key = namespace + namespaceSeparator + state;
-	      if (localStorage.getItem(key)) {
-	        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage.getItem(key))));
+	      var val = localStorage.getItem(key);
+	      if (val) {
+	        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(val)));
 	      } else {
 	        warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
 	      }

--- a/test/test.js
+++ b/test/test.js
@@ -1760,13 +1760,17 @@
 
 	*/
 
-	function warn(disableWarnings) {
-	  return function (warningMessage) {
-	    if (!disableWarnings) {
-	      console.warn(MODULE_NAME, warningMessage);
-	    }
-	  };
+	function warnConsole(warningMessage) {
+	  console.warn(MODULE_NAME, warningMessage);
 	}
+
+	function warnSilent(_warningMessage) {
+	  // Empty
+	}
+
+	var warn = function warn(disableWarnings) {
+	  return disableWarnings ? warnSilent : warnConsole;
+	};
 
 	// ---------------------------------------------------
 	/* lensPath

--- a/test/test.js
+++ b/test/test.js
@@ -1989,13 +1989,13 @@
 	        // Local function to avoid duplication of code above
 	        function _save() {
 	          if (states.length === 0) {
-	            localStorage[namespace] = JSON.stringify(state_);
+	            localStorage.setItem(namespace, JSON.stringify(state_));
 	          } else {
 	            states.forEach(function (state) {
 	              var key = namespace + namespaceSeparator + state;
 	              var stateForLocalStorage = getStateForLocalStorage(state, state_);
 	              if (stateForLocalStorage) {
-	                localStorage[key] = JSON.stringify(stateForLocalStorage);
+	                localStorage.setItem(key, JSON.stringify(stateForLocalStorage));
 	              } else {
 	                // Make sure nothing is ever saved for this incorrect state
 	                localStorage.removeItem(key);
@@ -2088,15 +2088,15 @@
 
 	  // Load all of the namespaced Redux data from LocalStorage into local Redux state tree
 	  if (states.length === 0) {
-	    if (localStorage[namespace]) {
-	      loadedState = JSON.parse(localStorage[namespace]);
+	    if (localStorage.getItem(namespace)) {
+	      loadedState = JSON.parse(localStorage.getItem(namespace));
 	    }
 	  } else {
 	    // Load only specified states into the local Redux state tree
 	    states.forEach(function (state) {
 	      var key = namespace + namespaceSeparator + state;
 	      if (localStorage.getItem(key)) {
-	        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[key])));
+	        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage.getItem(key))));
 	      } else {
 	        warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
 	      }
@@ -2177,7 +2177,10 @@
 	    namespace = NAMESPACE_DEFAULT;
 	  }
 
-	  for (var key in localStorage) {
+	  var len = localStorage.length;
+	  for (var ind = 0; ind < len; ind++) {
+	    var key = localStorage.key(ind);
+
 	    // key starts with namespace
 	    if (key.slice(0, namespace.length) === namespace) {
 	      localStorage.removeItem(key);

--- a/test/test.js
+++ b/test/test.js
@@ -1992,12 +1992,13 @@
 	            localStorage[namespace] = JSON.stringify(state_);
 	          } else {
 	            states.forEach(function (state) {
+	              var key = namespace + namespaceSeparator + state;
 	              var stateForLocalStorage = getStateForLocalStorage(state, state_);
 	              if (stateForLocalStorage) {
-	                localStorage[namespace + namespaceSeparator + state] = JSON.stringify(stateForLocalStorage);
+	                localStorage[key] = JSON.stringify(stateForLocalStorage);
 	              } else {
 	                // Make sure nothing is ever saved for this incorrect state
-	                localStorage.removeItem(namespace + namespaceSeparator + state);
+	                localStorage.removeItem(key);
 	              }
 	            });
 	          }
@@ -2093,10 +2094,11 @@
 	  } else {
 	    // Load only specified states into the local Redux state tree
 	    states.forEach(function (state) {
-	      if (localStorage.getItem(namespace + namespaceSeparator + state)) {
-	        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[namespace + namespaceSeparator + state])));
+	      var key = namespace + namespaceSeparator + state;
+	      if (localStorage.getItem(key)) {
+	        loadedState = (0, _objectMerge2.default)(loadedState, realiseObject(state, JSON.parse(localStorage[key])));
 	      } else {
-	        warn_("Invalid load '" + (namespace + namespaceSeparator + state) + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
+	        warn_("Invalid load '" + key + "' provided. Check your 'states' in 'load()'. If this is your first time running this app you may see this message. To disable it in future use the 'disableWarnings' flag, see documentation.");
 	      }
 	    });
 	  }


### PR DESCRIPTION
The main reason for this PR is to trap exceptions being thrown by `localStorage` (of which there are many weird cases across different platforms and browsers), and `JSON.parse()`.

Exceptions are logged to the console as warnings, by default, re-using `disableWarnings` to silence them. This means that `disableWarnings` is now needed as an option for `save()` and `clear()` as well.

Also includes some trivial refactoring in digestible small commits that steer toward the final commit.